### PR TITLE
Adds a far more obvious error message when save format patching fails due to old/leftover modified .dll files

### DIFF
--- a/src/features/custom_saves.cpp
+++ b/src/features/custom_saves.cpp
@@ -13,4 +13,24 @@ void CustomSaves::Initialize()
         Memory::PatchBytes((uintptr_t)SaveFormat, "\x2E\x00\x65\x00\x6E\x00\x32\x00", 8);
         spdlog::info("Save Format patched successfully.");
     }
+    else
+    {
+        spdlog::error("---------- OUTDATED DLL ERROR ----------");
+        spdlog::error("Failed to locate save format memory pattern in {}.", Memory::GetModuleName(g_GameDLLs.Engine, true));
+        spdlog::error("({})", Memory::GetModuleName(g_GameDLLs.Engine, false));
+        spdlog::error("This usually means leftover files from an old EnhancedSC install are still in your game folder.");
+        spdlog::error("Those old modified DLLs are no longer used - their changes are now built directly into our .ASI mod.");
+        spdlog::error("Please reinstall the game to restore the original files, then install the latest version of EnhancedSC.");
+        spdlog::error("---------- OUTDATED DLL ERROR ----------");
+        std::string MessageBoxMessage = "Failed to locate save format memory pattern in " + Memory::GetModuleName(g_GameDLLs.Engine, true) + ".\n"
+                                         "("+ Memory::GetModuleName(g_GameDLLs.Engine, false) +")\n"
+                                        "\n"
+                                        "This usually means leftover files from an old EnhancedSC install are still in your game folder.\n"
+                                        "\n"
+                                        "Those old modified DLLs are no longer used - their changes are now built directly into our .ASI mod.\n"
+                                        "\n"
+                                        "Please reinstall the game to restore the original DLL files, then install the latest version of EnhancedSC.";
+        MessageBoxA(nullptr, MessageBoxMessage.c_str(), "EnhancedSC Error", MB_OK | MB_ICONERROR);
+        ExitProcess(1);
+    }
 }

--- a/src/resources/helper.cpp
+++ b/src/resources/helper.cpp
@@ -38,6 +38,25 @@ namespace Memory
         return std::to_string(year) + "-" + std::to_string(month) + "-" + std::to_string(day);
     }
 
+
+
+    std::string GetModuleName(const HMODULE hMod, const bool filenameOnly = true)
+    {
+        char path[MAX_PATH];
+        DWORD len = GetModuleFileNameA(hMod, path, MAX_PATH);
+        if (len == 0)
+        {
+            return {};
+        }
+
+        if (filenameOnly)
+        {
+            return std::filesystem::path(path).filename().string();
+        }
+
+        return std::string(path, len);
+    }
+
     // CSGOSimple's pattern scan
     // https://github.com/OneshotGH/CSGOSimple-master/blob/master/CSGOSimple/helpers/utils.cpp
     std::uint8_t* PatternScanSilent(void* module, const char* signature)
@@ -96,7 +115,9 @@ namespace Memory
         else
         {
 
+            spdlog::error("---------- PATTERN SCAN FAILURE ----------");
             spdlog::error("{}: Pattern scan failed.", prefix);
+            spdlog::error("---------- PATTERN SCAN FAILURE ----------");
         }
         return foundPattern;
     }

--- a/src/resources/helper.hpp
+++ b/src/resources/helper.hpp
@@ -21,6 +21,8 @@ namespace Memory
 
     std::string GetModuleVersion(HMODULE module);
 
+    std::string GetModuleName(HMODULE hMod, bool filenameOnly);
+
     std::uint8_t* PatternScanSilent(void* module, const char* signature);
 
     std::uint8_t* PatternScan(void* module, const char* signature, const char* prefix);


### PR DESCRIPTION
Closes #102

<img width="544" height="370" alt="2025-09-15_08-29-55-SplinterCell-EnhancedSC_Error" src="https://github.com/user-attachments/assets/5e73a336-0145-4936-ab7c-9b23b3ba2009" />
