### PR TITLE
Implement controller rumble via native xinput

### DIFF
--- a/EnhancedSC.vcxproj
+++ b/EnhancedSC.vcxproj
@@ -11,6 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\features\controller_rumble.cpp" />
     <ClCompile Include="src\features\dpad_keybinds.cpp" />
     <ClCompile Include="external\safetyhook\src\allocator.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
@@ -71,6 +72,7 @@
     <ClCompile Include="src\features\use_xbox_fonts.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\features\controller_rumble.hpp" />
     <ClInclude Include="src\features\dpad_keybinds.hpp" />
     <ClInclude Include="external\safetyhook\include\safetyhook.hpp" />
     <ClInclude Include="src\fixes\mouse_xbuttons_support.hpp" />

--- a/EnhancedSC.vcxproj.filters
+++ b/EnhancedSC.vcxproj.filters
@@ -92,6 +92,9 @@
     <ClCompile Include="src\features\use_xbox_fonts.cpp">
       <Filter>Features</Filter>
     </ClCompile>
+    <ClCompile Include="src\features\controller_rumble.cpp">
+      <Filter>Features</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\features\intro_skip.hpp">
@@ -176,6 +179,9 @@
       <Filter>Features\Headers</Filter>
     </ClInclude>
     <ClInclude Include="src\features\use_xbox_fonts.hpp">
+      <Filter>Features\Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\features\controller_rumble.hpp">
       <Filter>Features\Headers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -26,6 +26,7 @@
 #include "submodule_initiailization.hpp"
 #include "use_xbox_fonts.hpp"
 #include "version_checker.hpp"
+#include "controller_rumble.hpp"
 
 ///WIP
 //#include "msaa.hpp"
@@ -72,7 +73,8 @@ void InitUWindow() //g_GameDLLs.UWindow
 {
 }
 void InitWinDrv() //g_GameDLLs.WinDrv
-{}
+{
+}
 
 void InitD3DDrv() //g_GameDLLs.D3DDrv
 {
@@ -99,6 +101,8 @@ void InitializeSubsystems()
         INITIALIZE(RestoreEAX::Initialize());
         INITIALIZE(DPadKeybinds::Initialize());
         INITIALIZE(UseXboxFonts::Toggle());
+        INITIALIZE(ControllerRumble::Fix());
+
 
         INITIALIZE(CheckForUpdates());
     }

--- a/src/features/controller_rumble.cpp
+++ b/src/features/controller_rumble.cpp
@@ -1,0 +1,52 @@
+#include "stdafx.h"
+#include "controller_rumble.hpp"
+
+#include "helper.hpp"
+#include "logging.hpp"
+#include "hook_dlls.hpp"
+
+#include <Xinput.h>
+#pragma comment(lib, "Xinput.lib")
+
+
+namespace
+{
+    constexpr float  RUMBLE_MIN_STRENGTH = 0.0f;
+    constexpr float  RUMBLE_MAX_STRENGTH = 1.0f;
+    constexpr WORD   RUMBLE_MAX_VALUE = 0xFFFF; // 65535, full motor speed
+
+    void UpdateRumble(const float vibrateStrength, const float shakeStrength)
+    {
+        const WORD left = static_cast<WORD>(std::clamp(vibrateStrength, RUMBLE_MIN_STRENGTH, RUMBLE_MAX_STRENGTH) * RUMBLE_MAX_VALUE); // low freq motor
+        const WORD right = static_cast<WORD>(std::clamp(shakeStrength, RUMBLE_MIN_STRENGTH, RUMBLE_MAX_STRENGTH) * RUMBLE_MAX_VALUE); // high freq motor
+
+        static WORD lastLeft = 0;
+        static WORD lastRight = 0;
+
+        // Don't spam the HID stack if the values haven't changed
+        if (left == lastLeft && right == lastRight)
+        {
+            return;
+        }
+        lastLeft = left;
+        lastRight = right;
+
+        XINPUT_VIBRATION vib = { left, right };
+        XInputSetState(0, &vib);
+    }
+}
+
+
+
+void ControllerRumble::Fix()
+{
+    if (!g_ControllerRumble.bEnabled)
+    {
+        return;
+    }
+    
+    MAKE_HOOK_MID(g_GameDLLs.Engine, "5F 89 4C 24", "Intercept APlayerController::UpdateRumble(float strength)", {
+        UpdateRumble(std::bit_cast<float>(ctx.ecx), std::bit_cast<float>(ctx.edx));
+        });
+
+}

--- a/src/features/controller_rumble.hpp
+++ b/src/features/controller_rumble.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+class ControllerRumble
+{
+public:
+    static void Fix();
+    bool bEnabled = false;
+};
+
+inline ControllerRumble g_ControllerRumble;

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -12,6 +12,7 @@
 #include "distance_culling.hpp"
 #include "idle_timers.hpp"
 #include "use_xbox_fonts.hpp"
+#include "controller_rumble.hpp"
 
 // -----------------------------------------------------------------------------
 // ConfigHelper: A type-safe, case-insensitive, error-checked INI config reader.
@@ -171,6 +172,9 @@ void Config::Read()
 
     ConfigHelper::getValue(ini, "Echelon.EchelonGameInfo", "bXboxFont", g_UseXboxFonts.bXboxFont);
     LOG_CONFIG(ConfigKeys::UseXboxFonts_Section, ConfigKeys::UseXboxFonts_Setting, g_UseXboxFonts.bXboxFont);
+
+    ConfigHelper::getValue(ini, "Echelon.EchelonGameInfo", "bEnableRumble", g_ControllerRumble.bEnabled);
+    LOG_CONFIG(ConfigKeys::EnableRumble_Section, ConfigKeys::EnableRumble_Setting, g_ControllerRumble.bEnabled);
 
     ConfigHelper::getValue(ini, "Echelon.EchelonGameInfo", "bCheckForUpdates", bShouldCheckForUpdates);
     LOG_CONFIG(ConfigKeys::CheckForUpdates_Section, ConfigKeys::CheckForUpdates_Setting, bShouldCheckForUpdates);

--- a/src/resources/config_keys.hpp
+++ b/src/resources/config_keys.hpp
@@ -22,6 +22,9 @@ namespace ConfigKeys
     constexpr const char* UseXboxFonts_Section = "Various";
     constexpr const char* UseXboxFonts_Setting = "Use Xbox Fonts";
 
+    constexpr const char* EnableRumble_Section = "Various";
+    constexpr const char* EnableRumble_Setting = "Enable Controller Rumble";
+
     // Internal
     constexpr const char* CheckForUpdates_Section = "Update Notifications";
     constexpr const char* CheckForUpdates_Setting = "Check For EnhancedSC Updates";


### PR DESCRIPTION
Needs a new var in Enhanced.ini, Echelon.EchelonGameInfo -> bEnableRumble

The UseRumble var in SplinterCell.ini is completely dead / no longer used.

Closes #25