### PR TITLE
Fix potential ini corruption if the game is alt-f4'd during startup

### DIFF
--- a/src/features/dpad_keybinds.cpp
+++ b/src/features/dpad_keybinds.cpp
@@ -90,16 +90,28 @@ void DPadKeybinds::Initialize()
 
     if (modified)
     {
-        std::ofstream outFile(SplinterCellUserIni, std::ios::trunc);
+        std::filesystem::path tmpPath = SplinterCellUserIni;
+        tmpPath += ".tmp";
+
+        if (std::filesystem::exists(tmpPath))
+        {
+            std::filesystem::remove(tmpPath);
+        }
+
+        std::ofstream outFile(tmpPath, std::ios::trunc);
         if (!outFile)
         {
-            spdlog::error("Error writing ini file {}.", SplinterCellUserIni.string());
+            spdlog::error("Error writing tmp ini file {}.", tmpPath.string());
             return;
         }
         for (const auto& l : lines)
         {
             outFile << l << "\n";
         }
+
+        outFile.close();
+
+        std::filesystem::rename(tmpPath, SplinterCellUserIni);
         spdlog::info("Patched {}", SplinterCellUserIni.string());
     }
     else

--- a/src/features/steam_deck_features.cpp
+++ b/src/features/steam_deck_features.cpp
@@ -76,16 +76,28 @@ namespace
 
         if (modified)
         {
-            std::ofstream outFile(SplinterCellUserIni, std::ios::trunc);
+            std::filesystem::path tmpPath = SplinterCellUserIni;
+            tmpPath += ".tmp";
+
+            if (std::filesystem::exists(tmpPath))
+            {
+                std::filesystem::remove(tmpPath);
+            }
+
+            std::ofstream outFile(tmpPath, std::ios::trunc);
             if (!outFile)
             {
-                spdlog::error("Error writing ini file {}.", SplinterCellUserIni.string());
+                spdlog::error("Error writing tmp ini file {}.", tmpPath.string());
                 return;
             }
             for (const auto& l : lines)
             {
                 outFile << l << "\n";
             }
+
+            outFile.close();
+
+            std::filesystem::rename(tmpPath, SplinterCellUserIni);
             spdlog::info("{} SteamDeck mode updated to: {}", SplinterCellUserIni.string(), DesiredSetting);
         }
         else


### PR DESCRIPTION
I ended up with a corrupt SplinterCell.ini during some testing earlier. This safeguards against that being possible by switching to atomic write temporary file -> rename/replace operations when updating ini values.

> From Steamworks's documentation on best practices for cloud saves:
> "We recommend that you write save data to a temporary file, and then rename the temporary file to the actual save file."
> "Renaming is an atomic operation and ensures that at no point is the file in an incomplete or invalid state."