### PR TITLE
Adds warnings if gamesave folders are not writable, and if any save files are set to read-only. 

### DIFF
--- a/EnhancedSC.vcxproj
+++ b/EnhancedSC.vcxproj
@@ -11,6 +11,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\warnings\check_gamesave_folder.cpp" />
     <ClCompile Include="src\warnings\ini_read_state.cpp" />
     <ClCompile Include="src\features\controller_rumble.cpp" />
     <ClCompile Include="src\features\dpad_keybinds.cpp" />
@@ -73,6 +74,7 @@
     <ClCompile Include="src\features\use_xbox_fonts.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\warnings\check_gamesave_folder.hpp" />
     <ClInclude Include="src\warnings\ini_read_state.hpp" />
     <ClInclude Include="src\features\controller_rumble.hpp" />
     <ClInclude Include="src\features\dpad_keybinds.hpp" />

--- a/EnhancedSC.vcxproj.filters
+++ b/EnhancedSC.vcxproj.filters
@@ -98,6 +98,9 @@
     <ClCompile Include="src\warnings\ini_read_state.cpp">
       <Filter>Warnings</Filter>
     </ClCompile>
+    <ClCompile Include="src\warnings\check_gamesave_folder.cpp">
+      <Filter>Warnings</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\features\intro_skip.hpp">
@@ -188,6 +191,9 @@
       <Filter>Features\Headers</Filter>
     </ClInclude>
     <ClInclude Include="src\warnings\ini_read_state.hpp">
+      <Filter>Warnings\Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="src\warnings\check_gamesave_folder.hpp">
       <Filter>Warnings\Headers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -22,6 +22,7 @@
 
 //Warnings
 #include "asi_loader_checks.hpp"
+#include "check_gamesave_folder.hpp"
 #include "steam_deck_features.hpp"
 #include "submodule_initiailization.hpp"
 #include "use_xbox_fonts.hpp"
@@ -104,6 +105,7 @@ void InitializeSubsystems()
         INITIALIZE(UseXboxFonts::Toggle());
         INITIALIZE(ControllerRumble::Fix());
         INITIALIZE(CheckINIReadPermissions::CheckStatus());
+        INITIALIZE(CheckGamesaveFolderWritable::CheckStatus());
 
 
         INITIALIZE(CheckForUpdates());

--- a/src/resources/config.cpp
+++ b/src/resources/config.cpp
@@ -4,6 +4,7 @@
 
 #include <inipp/inipp.h>
 
+#include "check_gamesave_folder.hpp"
 #include "logging.hpp"
 #include "version_checker.hpp"
 #include "config_keys.hpp"
@@ -184,6 +185,9 @@ void Config::Read()
 
     ConfigHelper::getValue(ini, "Echelon.EchelonGameInfo", "bWarnReadOnlyInis", CheckINIReadPermissions::Enabled);
     LOG_CONFIG(ConfigKeys::WarnReadOnlyINIFiles_Section, ConfigKeys::WarnReadOnlyINIFiles_Setting, CheckINIReadPermissions::Enabled);
+
+    ConfigHelper::getValue(ini, "Echelon.EchelonGameInfo", "bWarnReadOnlySaveFiles", CheckGamesaveFolderWritable::CheckSaveFiles);
+    LOG_CONFIG(ConfigKeys::WarnReadOnlySaveFiles_Section, ConfigKeys::WarnReadOnlySaveFiles_Setting, CheckGamesaveFolderWritable::CheckSaveFiles);
 
     bool bSteamDeckMode = false;
     ConfigHelper::getValue(ini, "Echelon.EchelonGameInfo", "bSteamDeckMode", bSteamDeckMode); // Not actually used, just to verify config key exists.

--- a/src/resources/config_keys.hpp
+++ b/src/resources/config_keys.hpp
@@ -36,4 +36,7 @@ namespace ConfigKeys
     constexpr const char* WarnReadOnlyINIFiles_Section = "Warnings";
     constexpr const char* WarnReadOnlyINIFiles_Setting = "Check for read-only INI files.";
 
+    constexpr const char* WarnReadOnlySaveFiles_Section = "Warnings";
+    constexpr const char* WarnReadOnlySaveFiles_Setting = "Check for read-only gamesave files.";
+
 }

--- a/src/resources/helper.cpp
+++ b/src/resources/helper.cpp
@@ -651,6 +651,17 @@ namespace Util
     }
 
 
+    bool IsFileReadOnly(const std::filesystem::path& path)
+    {
+        DWORD attrs = GetFileAttributesW(path.wstring().c_str());
+        if (attrs == INVALID_FILE_ATTRIBUTES)
+        {
+            std::wcerr << L"[ERROR] Failed to get attributes for: " << path << std::endl;
+            spdlog::error("Failed to get attributes for file: {}", path.string());
+            return false;
+        }
 
+        return (attrs & FILE_ATTRIBUTE_READONLY) != 0;
+    }
 
 }

--- a/src/resources/helper.hpp
+++ b/src/resources/helper.hpp
@@ -75,6 +75,9 @@ namespace Util
 
     int compareSemVer(const std::string& a, const std::string& b);
 
+
+    bool IsFileReadOnly(const std::filesystem::path& path);
+
 }
 
 

--- a/src/warnings/check_gamesave_folder.cpp
+++ b/src/warnings/check_gamesave_folder.cpp
@@ -1,0 +1,148 @@
+#include "stdafx.h"
+#include "check_gamesave_folder.hpp"
+
+#include "common.hpp"
+#include "logging.hpp"
+void CheckGamesaveFolderWritable::CheckStatus()
+{
+    const std::filesystem::path baseSave = sExePath.parent_path().parent_path() / "Save";
+    spdlog::info("Verifying gamesave directory is writeable: {}", baseSave.string());
+
+    const std::vector<std::filesystem::path> baseFolders = {
+        baseSave,
+        baseSave / "Profiles",
+        baseSave / "Sam"
+    };
+
+    bool success = true;
+
+    // Make sure all save folders exist
+    for (const auto& dir : baseFolders)
+    {
+        try
+        {
+            if (!std::filesystem::exists(dir))
+            {
+                spdlog::info("Directory '{}' does not exist. Creating...", dir.string());
+                std::filesystem::create_directories(dir);
+            }
+        }
+        catch (const std::exception& ex)
+        {
+            Logging::ShowConsole();
+            std::cerr << "Error creating folder '" << dir << "': " << ex.what() << std::endl;
+            spdlog::error("Failed to create folder '{}': {}", dir.string(), ex.what());
+            success = false;
+        }
+    }
+
+    if (!success)
+    {
+        return;
+    }
+
+    // Make sure all save folders are writable.
+    try
+    {
+        for (const auto& entry : std::filesystem::recursive_directory_iterator(baseSave))
+        {
+            if (!entry.is_directory())
+            {
+                continue;
+            }
+
+            const auto& dir = entry.path();
+            const auto testFile = dir / "write_test.tmp";
+
+            std::error_code ec;
+            std::filesystem::remove(testFile, ec);
+            if (ec)
+            {
+                Logging::ShowConsole();
+                std::cerr << "ERROR: Failed to remove leftover save test file from a previous launch in " << dir << ": " << ec.message() << std::endl;
+                std::cerr << "ERROR: This typically indicates that the folder is set to read-only, which breaks game saving." << std::endl;
+                spdlog::error("Failed to remove leftover test file from previous launch in '{}': {}", dir.string(), ec.message());
+                success = false;
+                continue;
+            }
+
+            std::ofstream ofs(testFile, std::ios::out | std::ios::trunc);
+            if (!ofs.is_open())
+            {
+                Logging::ShowConsole();
+                std::cerr << "ERROR: Cannot write to " << dir << std::endl;
+                std::cerr << "ERROR: This typically indicates that the folder is set to read-only, which breaks game saving." << std::endl;
+                spdlog::error("Cannot write to directory '{}'. Please check folder permissions.", dir.string());
+
+                success = false;
+                continue;
+            }
+
+            ofs << "test";
+            ofs.close();
+
+            std::filesystem::remove(testFile, ec);
+            if (ec)
+            {
+                spdlog::error("Failed to remove temporary save test file in '{}': {}", dir.string(), ec.message());
+                success = false;
+                continue;
+            }
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        Logging::ShowConsole();
+        std::cerr << "Error while checking save folder writability: " << ex.what() << std::endl;
+        spdlog::error("Exception while checking save folder writability: {}", ex.what());
+        success = false;
+    }
+
+    if (!success)
+    {
+        return;
+    }
+
+    if (!CheckSaveFiles)
+    {
+        spdlog::info("All gamesave folders are writable. Save file read-only check disabled by config.");
+        return;
+    }
+
+    spdlog::info("All gamesave folders are writable. Checking individual save files for read-only attribute.");
+
+    size_t readOnlyCount = 0;
+
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(baseSave))
+    {
+        if (!entry.is_regular_file())
+        {
+            continue;
+        }
+
+        const auto& filePath = entry.path();
+
+        if (Util::IsFileReadOnly(filePath))
+        {
+            Logging::ShowConsole();
+
+            std::wcout << L"[WARNING: READ-ONLY FILE] " << filePath << std::endl;
+            spdlog::warn("Detected read-only save file: {}", filePath.string());
+            ++readOnlyCount;
+        }
+    }
+
+    if (readOnlyCount > 0)
+    {
+        std::cout << "\nWARNING: " << readOnlyCount << " file" << (readOnlyCount > 1 ? "s are" : " is") << " set to read-only in the Save folder." << std::endl;
+        std::cout << "Game saving may fail until these files are made writable.\n" << std::endl;
+
+        spdlog::warn("{} save file{} detected as read-only.", readOnlyCount, (readOnlyCount > 1 ? "s" : ""));
+        spdlog::warn("Game saving may fail until these files are made writable.");
+    }
+    else
+    {
+        spdlog::info("All gamesave folders and files verified as writable.");
+    }
+
+}

--- a/src/warnings/check_gamesave_folder.hpp
+++ b/src/warnings/check_gamesave_folder.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace CheckGamesaveFolderWritable
+{
+    void CheckStatus();
+
+    inline bool CheckSaveFiles = true;
+}
+

--- a/src/warnings/ini_read_state.cpp
+++ b/src/warnings/ini_read_state.cpp
@@ -4,23 +4,6 @@
 #include "common.hpp"
 #include "logging.hpp"
 
-
-namespace
-{
-    bool IsFileReadOnly(const std::filesystem::path& path)
-    {
-        DWORD attrs = GetFileAttributesW(path.wstring().c_str());
-        if (attrs == INVALID_FILE_ATTRIBUTES)
-        {
-            std::wcerr << L"[ERROR] Failed to get attributes for: " << path << std::endl;
-            spdlog::error("Failed to get attributes for file: {}", path.string());
-            return false;
-        }
-
-        return (attrs & FILE_ATTRIBUTE_READONLY) != 0;
-    }
-}
-
 void CheckINIReadPermissions::CheckStatus()
 {
     if (!Enabled)
@@ -46,7 +29,7 @@ void CheckINIReadPermissions::CheckStatus()
             continue;
         }
 
-        if (IsFileReadOnly(filePath))
+        if (Util::IsFileReadOnly(filePath))
         {
 
             Logging::ShowConsole();


### PR DESCRIPTION
Save file read-only checks can be disabled with  `Echelon.EchelonGameInfo` -> `bWarnReadOnlySaveFiles`. Folder writability will still be verified. 

Resolves https://www.reddit.com/r/Splintercell/comments/1ocnw7c/cant_quicksave_or_save_at_all_splinter_cell_1_pc/
